### PR TITLE
Update rp2040_usb.c

### DIFF
--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -161,7 +161,10 @@ void _hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t t
     // Fill in info now that we're kicking off the hw
     ep->total_len = total_len;
     ep->len = 0;
-    ep->transfer_size = tu_min16(total_len, ep->wMaxPacketSize);
+    // The following limits the TOTAL transfer size to 64 bytes.
+    // This is not the maximum size of the individual data packets,
+    // so it does not need to be limited to 8 for low-speed devices.
+    ep->transfer_size = total_len > 64 ? 64 : total_len;
     ep->active = true;
     ep->user_buf = buffer;
 #if TUSB_OPT_HOST_ENABLED


### PR DESCRIPTION
Revert a change that was made to rp2040_usb.c that causes slow speed devices to not get configured by the host.

**Describe the PR**
A clear and concise description of what this PR solve.

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
